### PR TITLE
Fix image upload

### DIFF
--- a/wp-export-to-json.js
+++ b/wp-export-to-json.js
@@ -333,7 +333,11 @@ if (!fs.existsSync(uploadsDir)) fs.mkdirSync(uploadsDir);
 
 const allImages = {};
 allUrls.forEach((u) => {
-  const wpUploadBase = site.baseUrl + "/wp-content/uploads/";
+  let wpUploadBase = site.baseUrl + '/wp-content/uploads/';
+
+  if (u.startsWith('http') && !u.startsWith('https')) {
+    wpUploadBase = wpUploadBase.replace('https', 'http');
+  }
   if (
     u.length <= wpUploadBase.length ||
     u.substring(0, wpUploadBase.length) !== wpUploadBase

--- a/wp-json-to-strapi.js
+++ b/wp-json-to-strapi.js
@@ -26,9 +26,14 @@ const wpAuthors = JSON.parse(
 const wpPosts = JSON.parse(
   fs.readFileSync("./wp-export/posts/post_collection.json", "utf8")
 );
-const wpAttachments = JSON.parse(
-  fs.readFileSync("./wp-export/posts/attachment_collection.json", "utf8")
-);
+let wpAttachments;
+try {
+  wpAttachments = JSON.parse(
+    fs.readFileSync("./wp-export/posts/attachment_collection.json", "utf8")
+  );
+} catch (e) {
+  console.log(e);
+}
 const manifest = JSON.parse(
   fs.readFileSync("./wp-export/uploads/manifest.json", "utf8")
 );
@@ -566,18 +571,20 @@ const uploadMedia = async () => {
     if (!existing) continue;
 
     let hasUpdate = false;
-    const attachments = wpAttachments.filter(
-      (f) => f.parentId === existing.attributes.wp_id
-    );
-    if (attachments && attachments.length > 0) {
-      for (let ai = 0; ai < attachments.length; ai++) {
-        const url = attachments[ai].attachmentUrl;
-        if (url && allMedia[url] && urlToExistingFileMap[url]) {
-          if (existing.feature_image == null) {
-            existing.feature_image = { id: urlToExistingFileMap[url].id };
-            featureImageUpdates++;
-            hasUpdate = true;
-            break;
+    if (wpAttachments) {
+      const attachments = wpAttachments.filter(
+        (f) => f.parentId === existing.attributes.wp_id
+      );
+      if (attachments && attachments.length > 0) {
+        for (let ai = 0; ai < attachments.length; ai++) {
+          const url = attachments[ai].attachmentUrl;
+          if (url && allMedia[url] && urlToExistingFileMap[url]) {
+            if (existing.feature_image == null) {
+              existing.feature_image = { id: urlToExistingFileMap[url].id };
+              featureImageUpdates++;
+              hasUpdate = true;
+              break;
+            }
           }
         }
       }

--- a/wp-json-to-strapi.js
+++ b/wp-json-to-strapi.js
@@ -76,7 +76,7 @@ const _upload = async (file, name, caption, alternativeText) => {
         content_type: mime.contentType(file),
       },
     };
-    const { body } = await needle("post", strapiUrl + "/upload", data, {
+    const { body } = await needle("post", strapiUrl + "/api/upload", data, {
       multipart: true,
       headers: {
         authorization: _axios.defaults.headers.Authorization,
@@ -281,41 +281,41 @@ const importPosts = async (doUpdates) => {
     const urlSubstitutions = {};
     wpPosts.forEach((p) => {
       const dtUrl =
-          p.postDate && p.postDate.length
-              ? moment.utc(p.postDate).format("YYYY/MM/DD")
-              : null;
+        p.postDate && p.postDate.length
+          ? moment.utc(p.postDate).format("YYYY/MM/DD")
+          : null;
       if (!p.slug || p.slug.length === 0) p.slug = slugify(p.title);
       if (p.link && p.link.length) {
         if (dtUrl) {
           urlSubstitutions[
-              `${site.baseUrl}/${dtUrl}/${p.slug}/`
-              ] = `/blog/${p.slug}`;
+            `${site.baseUrl}/${dtUrl}/${p.slug}/`
+          ] = `/blog/${p.slug}`;
           urlSubstitutions[
-              `${site.baseUrl}/${dtUrl}/${p.slug}/`
-              ] = `/blog/${p.slug}`;
+            `${site.baseUrl}/${dtUrl}/${p.slug}/`
+          ] = `/blog/${p.slug}`;
         }
         urlSubstitutions[p.link] = `/blog/${p.slug}`;
       }
     });
     console.log(`Attempting to import ${wpPosts.length} posts`);
     let newPosts = 0,
-        dupePosts = 0;
+      dupePosts = 0;
     for (let wpPostIndex = 0; wpPostIndex < wpPosts.length; wpPostIndex++) {
       const wpPost = wpPosts[wpPostIndex];
       if (!wpPost.title) continue;
       console.log("wpPost", wpPost);
       // console.log("existingPosts.filter", existingPosts.filter(post => !post.slug).map(post => ({...post})));
       const existing = existingPosts.find(
-          (t) => t.attributes.slug.toLowerCase() === wpPost.slug.toLowerCase()
+        (t) => t.attributes.slug.toLowerCase() === wpPost.slug.toLowerCase()
       );
       const publish_date =
-          wpPost.pubDate && wpPost.pubDate.length > 0
-              ? moment.utc(wpPost.pubDate).toISOString()
-              : null;
+        wpPost.pubDate && wpPost.pubDate.length > 0
+          ? moment.utc(wpPost.pubDate).toISOString()
+          : null;
       const original_date =
-          wpPost.postDate && wpPost.postDate.length > 0
-              ? moment(wpPost.postDate).toISOString()
-              : null;
+        wpPost.postDate && wpPost.postDate.length > 0
+          ? moment(wpPost.postDate).toISOString()
+          : null;
       let markdown = wpPost.markdown || "";
       let excerpt = wpPost.encodedExcerpt || "";
       wpPost.urls.forEach((url) => {
@@ -325,22 +325,22 @@ const importPosts = async (doUpdates) => {
         }
       });
       const user =
-          users.find((u) => u.username === wpPost.creator) || defaultUser;
+        users.find((u) => u.username === wpPost.creator) || defaultUser;
       if (!existing) {
         if (user) {
           await _post("/api/posts", {
-              data: {
-                slug: wpPost.slug,
-                title: wpPost.title.__cdata,
-                body: markdown,
-                excerpt: excerpt,
-                publish_date,
+            data: {
+              slug: wpPost.slug,
+              title: wpPost.title.__cdata,
+              body: markdown,
+              excerpt: excerpt,
+              publish_date,
                 published: wpPost.status === "publish",
-                author: {
-                  id: user.id
-                },
-                original_date,
-                wp_id: wpPost.id,
+              author: {
+                id: user.id
+              },
+              original_date,
+              wp_id: wpPost.id,
               }
           });
           console.log("POSTS API")
@@ -365,12 +365,12 @@ const importPosts = async (doUpdates) => {
     }
     if (missingUsers.length > 0) {
       console.log(
-          `  Unable to import posts due to ${missingUsers.length} missing users: `,
-          new Set(missingUsers).values()
+        `  Unable to import posts due to ${missingUsers.length} missing users: `,
+        new Set(missingUsers).values()
       );
     }
     console.log(
-        `  Imported ${newPosts} new posts, updated ${dupePosts} existing posts`
+      `  Imported ${newPosts} new posts, updated ${dupePosts} existing posts`
     );
     // ++++++++++++++++++++++++++++++++++++++++++++++++++++
     // update post tags & categories
@@ -382,7 +382,7 @@ const importPosts = async (doUpdates) => {
     console.log("CATEGORIES API")
 
     const wpCategories = JSON.parse(
-        fs.readFileSync("./wp-export/categories.json", "utf8")
+      fs.readFileSync("./wp-export/categories.json", "utf8")
     );
     const tags = (await _axios.get("/api/tags?_limit=-1")).data;
     const wpTags = JSON.parse(fs.readFileSync("./wp-export/tags.json", "utf8"));
@@ -393,19 +393,19 @@ const importPosts = async (doUpdates) => {
       if (!wpPost.slug || wpPost.slug.length === 0)
         wpPost.slug = slugify(wpPost.title);
       const existing = existingPosts.find(
-          (t) => t.attributes.slug.toLowerCase() === wpPost.slug.toLowerCase()
+        (t) => t.attributes.slug.toLowerCase() === wpPost.slug.toLowerCase()
       );
       const catIds = [];
       const tagIds = [];
       if (
-          existing &&
-          (!existing.categories || existing.categories.length === 0) &&
-          wpPost.categoryIds &&
-          wpPost.categoryIds.length > 0
+        existing &&
+        (!existing.categories || existing.categories.length === 0) &&
+        wpPost.categoryIds &&
+        wpPost.categoryIds.length > 0
       ) {
         for (let ci = 0; ci < wpPost.categoryIds.length; ci++) {
           const wpCatSlug = (
-              wpCategories.find((g) => g.id === wpPost.categoryIds[ci]) || {}
+            wpCategories.find((g) => g.id === wpPost.categoryIds[ci]) || {}
           ).slug;
           if (wpCatSlug) {
             const cat = categories.find((s) => wpCatSlug === s.slug);
@@ -414,10 +414,10 @@ const importPosts = async (doUpdates) => {
         }
       }
       if (
-          existing &&
-          (!existing.tags || existing.tags.length === 0) &&
-          wpPost.tagIds &&
-          wpPost.tagIds.length > 0
+        existing &&
+        (!existing.tags || existing.tags.length === 0) &&
+        wpPost.tagIds &&
+        wpPost.tagIds.length > 0
       ) {
         for (let ci = 0; ci < wpPost.tagIds.length; ci++) {
           const wpTagSlug = (wpTags.find((g) => g.id === wpPost.tagIds[ci]) || {})
@@ -466,14 +466,14 @@ const importPosts = async (doUpdates) => {
       if (!wpPost.slug || wpPost.slug.length === 0)
         wpPost.slug = slugify(wpPost.title);
       const existing = existingPosts.find(
-          (t) => t.attributes.slug.toLowerCase() === wpPost.slug.toLowerCase()
+        (t) => t.attributes.slug.toLowerCase() === wpPost.slug.toLowerCase()
       );
       if (!existing || !wpPost.comments || wpPost.comments.length === 0) continue;
 
       // does the post have comments
       if (
-          existingComments.findIndex((c) => c.post && c.post.id === existing.id) >
-          -1
+        existingComments.findIndex((c) => c.post && c.post.id === existing.id) >
+        -1
       ) {
         continue; // no need to populate comments if they were already populated
       }
@@ -488,14 +488,14 @@ const importPosts = async (doUpdates) => {
           const wpAuthor = wpAuthors.find((a) => a.id === wpComment.userId);
           if (wpAuthor && wpAuthor.id > 0) {
             const eUser =
-                users.find((u) => u.username === wpAuthor.login) || defaultUser;
+              users.find((u) => u.username === wpAuthor.login) || defaultUser;
             if (eUser) user = {id: eUser.id};
           }
         }
         const parent =
-            wpComment.parentId && wpComment.parentId > 0
-                ? sComments[`c-${wpComment.parentId}`]
-                : null;
+          wpComment.parentId && wpComment.parentId > 0
+            ? sComments[`c-${wpComment.parentId}`]
+            : null;
         let newComment = {
           author: wpComment.author,
           author_email: wpComment.authorEmail,
@@ -520,7 +520,7 @@ const importPosts = async (doUpdates) => {
       }
     }
     console.log(
-        `  Added ${commentsCount} post comments, ${commentErrors} post errors`
+      `  Added ${commentsCount} post comments, ${commentErrors} post errors`
     );
   } catch (e) {
     console.error(e?.response?.data);
@@ -560,12 +560,14 @@ const uploadMedia = async () => {
   let postUpdates = 0;
   for (let wpPostIndex = 0; wpPostIndex < wpPosts.length; wpPostIndex++) {
     const wpPost = wpPosts[wpPostIndex];
-    const existing = existingPosts.find((t) => t.wp_id === wpPost.id);
+    const existing = existingPosts.find(
+      (t) => t.attributes.wp_id === wpPost.id
+    );
     if (!existing) continue;
 
     let hasUpdate = false;
     const attachments = wpAttachments.filter(
-      (f) => f.parentId === existing.wp_id
+      (f) => f.parentId === existing.attributes.wp_id
     );
     if (attachments && attachments.length > 0) {
       for (let ai = 0; ai < attachments.length; ai++) {
@@ -584,17 +586,18 @@ const uploadMedia = async () => {
     for (let ui = 0; ui < wpPost.urls.length; ui++) {
       const url = wpPost.urls[ui];
       if (allMedia[url] && urlToExistingFileMap[url]) {
-        const previousBody = existing.body;
-        existing.body = existing.body.replaceAll(
+        const previousBody = existing.attributes.body;
+        existing.attributes.body = existing.attributes.body.replaceAll(
           url,
           urlToExistingFileMap[url].url
         );
-        if (previousBody.length !== existing.body.length) hasUpdate = true;
+        if (previousBody.length !== existing.attributes.body.length)
+          hasUpdate = true;
       }
     }
 
     if (hasUpdate) {
-      await _put(`/api/posts/${existing.id}`, existing);
+      await _put(`/api/posts/${existing.id}`, { data: existing.attributes });
       postUpdates++;
     }
   }


### PR DESCRIPTION
## This PR fixes the script for image upload.

## Fixes implemented

### 1. Adapt to strapiv4 api
   - `existing.body` -> `existing.attributes.body`
   - ``_put(`/api/posts/${existing.id}`, existing )`` -> ``_put(`/api/posts/${existing.id}`, { data: existing.attributes })``
   - `/upload` -> `/api/upload`

### 2. Handle the absence of `attachment_collection.json` file

### 3. Fix image urls that do not start with `https://clubs.ntu.edu.sg/csec/` not being uploaded
Remove the following code:
``` javascript
  let wpUploadBase = site.baseUrl + '/wp-content/uploads/';

  if (u.startsWith('http') && !u.startsWith('https')) {
    wpUploadBase = wpUploadBase.replace('https', 'http');
  }
  if (
    u.length <= wpUploadBase.length ||
    u.substring(0, wpUploadBase.length) !== wpUploadBase
  )
    return;
```

### 4. Fix placeholder image not being copied correctly

### 5. Added 2 folders in image uploads: `success` and `fail`
- success: file downloaded successfully
- fail: file failed to download, placeholder used instead

### 6. Fix GET posts returning only 25 posts at a time
Instead of fetching the the list of posts at the start, fetch the post one at a time with a filter:
```javascript
const existing = (
  await _axios.get(`/api/posts?filters[wp_id][$eq]=${wpPost.id}`)
).data.data[0];
```
[SCSE-105]